### PR TITLE
Add back in single-reach sets

### DIFF
--- a/sets/getAllSets.py
+++ b/sets/getAllSets.py
@@ -71,6 +71,7 @@ def SetParameters(algo):
         params['MaximumReachesEachDirection']=2
         params['MinimumReaches']=3
         params['AllowedReachOverlap']=-1 # specify -1 to just remove duplicates
+        params['']
     elif algo == 'HiVDI':
         params['RequireIdenticalOrbits']=False
         params['DrainageAreaPctCutoff']=30.


### PR DESCRIPTION
Biggest issue with first cut at set finder for HiVDI and SIC was that it omitted single-reach sets; some reaches were not in a set at all. This simply determines the missing reaches, and creates single-reach sets for them. Does not affect MetroMan.